### PR TITLE
Remove unused socket.io module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "deep-pluck": "^0.1.2",
     "express": "^4.12.3",
-    "socket.io": "^1.3.5",
     "winston": "^1.0.0",
     "ws": "yarax/ws"
   }


### PR DESCRIPTION
I see that socket.io is added to the module dependencies but I don't see it used anywhere. Would be useful to spare some CPU time for other stuff rather than compiling socket.io modules.
